### PR TITLE
Add _created and _updated metalables

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -52,9 +52,9 @@ type server struct {
 }
 
 var testEntities = []etre.Entity{
-	{"_id": "59f10d2a5669fc79103a0000", "_type": "node", "_rev": int64(0), "x": "1", "foo": "bar"},
-	{"_id": "59f10d2a5669fc79103a1111", "_type": "node", "_rev": int64(0), "x": "2", "foo": "bar"},
-	{"_id": "59f10d2a5669fc79103a2222", "_type": "node", "_rev": int64(0), "x": "3", "foo": "bar"},
+	{"_id": "59f10d2a5669fc79103a0000", "_type": "node", "_rev": int64(0), "_created": int64(1000), "_updated": int64(2000), "x": "1", "foo": "bar"},
+	{"_id": "59f10d2a5669fc79103a1111", "_type": "node", "_rev": int64(0), "_created": int64(3000), "_updated": int64(4000), "x": "2", "foo": "bar"},
+	{"_id": "59f10d2a5669fc79103a2222", "_type": "node", "_rev": int64(0), "_created": int64(5000), "_updated": int64(6000), "x": "3", "foo": "bar"},
 }
 
 var testEntityIds = []string{"59f10d2a5669fc79103a0000", "59f10d2a5669fc79103a1111", "59f10d2a5669fc79103a2222"}
@@ -66,9 +66,9 @@ var (
 )
 
 var testEntitiesWithObjectIDs = []etre.Entity{
-	{"_id": testEntityId0, "_type": "node", "_rev": int64(0), "x": "1", "foo": "bar"},
-	{"_id": testEntityId1, "_type": "node", "_rev": int64(0), "x": "2", "foo": "bar"},
-	{"_id": testEntityId2, "_type": "node", "_rev": int64(0), "x": "3", "foo": "bar"},
+	{"_id": testEntityId0, "_type": "node", "_rev": int64(0), "_created": int64(1000), "_updated": int64(2000), "x": "1", "foo": "bar"},
+	{"_id": testEntityId1, "_type": "node", "_rev": int64(0), "_created": int64(3000), "_updated": int64(4000), "x": "2", "foo": "bar"},
+	{"_id": testEntityId2, "_type": "node", "_rev": int64(0), "_created": int64(5000), "_updated": int64(6000), "x": "3", "foo": "bar"},
 }
 
 var defaultConfig = config.Config{
@@ -125,11 +125,13 @@ func uri(id string) string {
 	return addr + etre.API_ROOT + "/entity/" + id
 }
 
-func fixRev(e []etre.Entity) {
-	for i := range e {
-		f := e[i]["_rev"].(float64)
-		delete(e[i], "_rev")
-		e[i]["_rev"] = int64(f)
+func fixInt64(e []etre.Entity) {
+	for _, label := range []string{"_rev", "_updated", "_created"} {
+		for i := range e {
+			f := e[i][label].(float64)
+			delete(e[i], label)
+			e[i][label] = int64(f)
+		}
 	}
 }
 

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -52,7 +52,7 @@ func TestQueryBasic(t *testing.T) {
 	expectFilter := etre.QueryFilter{}
 	assert.Equal(t, expectFilter, gotFilter)
 
-	fixRev(gotEntities) // JSON float64(_rev) ->, int64(_rev)
+	fixInt64(gotEntities) // JSON float64(_rev) ->, int64(_rev)
 	assert.Equal(t, testEntities, gotEntities)
 
 	// -- Metrics -----------------------------------------------------------

--- a/api/single_entity_read_test.go
+++ b/api/single_entity_read_test.go
@@ -55,7 +55,7 @@ func TestGetEntityBasic(t *testing.T) {
 	expectFilter := etre.QueryFilter{}
 	assert.Equal(t, expectFilter, gotFilter)
 
-	fixRev([]etre.Entity{gotEntity}) // JSON float64(_rev) ->, int64(_rev)
+	fixInt64([]etre.Entity{gotEntity}) // JSON float64(_rev) ->, int64(_rev)
 	assert.Equal(t, testEntities[0], gotEntity)
 
 	// -- Metrics -----------------------------------------------------------

--- a/client_test.go
+++ b/client_test.go
@@ -145,6 +145,9 @@ func TestQueryOK(t *testing.T) {
 		{
 			"_id":      "abc",
 			"hostname": "localhost",
+			"_rev":     float64(0), // json.Unmarshal will convert int64 to float64, so use float64 here so the asserts are okay
+			"_created": float64(1000),
+			"_updated": float64(2000),
 		},
 	}
 
@@ -162,6 +165,9 @@ func TestQueryOK(t *testing.T) {
 	assert.Equal(t, "query="+query, gotQuery)
 	assert.Equal(t, got, respData)
 	assert.Equal(t, ctx, httpRT.gotCtx)
+	assert.Equal(t, int64(0), got[0].Rev())
+	assert.Equal(t, time.Unix(0, 1000), got[0].Created())
+	assert.Equal(t, time.Unix(0, 2000), got[0].Updated())
 }
 
 func TestQueryNoResults(t *testing.T) {

--- a/entity/store.go
+++ b/entity/store.go
@@ -129,10 +129,13 @@ func (s store) CreateEntities(wo WriteOp, entities []etre.Entity) ([]string, err
 	// A slice of IDs we generate to insert along with entities into DB
 	newIds := make([]string, 0, len(entities))
 
+	now := time.Now().UnixNano()
 	for i := range entities {
 		entities[i]["_id"] = primitive.NewObjectID()
 		entities[i]["_type"] = wo.EntityType
 		entities[i]["_rev"] = int64(0)
+		entities[i]["_created"] = now
+		entities[i]["_updated"] = now
 
 		res, err := c.InsertOne(s.ctx, entities[i])
 		if err != nil {
@@ -187,6 +190,7 @@ func (s store) UpdateEntities(wo WriteOp, q query.Query, patch etre.Entity) ([]e
 	// diffs is a slice made up of a diff for each doc updated
 	diffs := []etre.Entity{}
 
+	patch["_updated"] = time.Now().UnixNano()
 	updates := bson.M{
 		"$set": patch,
 		"$inc": bson.M{
@@ -194,7 +198,7 @@ func (s store) UpdateEntities(wo WriteOp, q query.Query, patch etre.Entity) ([]e
 		},
 	}
 
-	p := bson.M{"_id": 1, "_type": 1, "_rev": 1}
+	p := bson.M{"_id": 1, "_type": 1, "_rev": 1, "_updated": 1}
 	for label := range patch {
 		p[label] = 1
 	}

--- a/entity/validate.go
+++ b/entity/validate.go
@@ -86,7 +86,7 @@ func (v validator) Entities(entities []etre.Entity, op byte) error {
 			switch op {
 			case VALIDATE_ON_CREATE:
 				// User cannot set these metalabels on create
-				for _, ml := range []string{"_id", "_type", "_rev", "_ts"} {
+				for _, ml := range []string{"_id", "_type", "_rev", "_created", "_updated"} {
 					if label != ml {
 						continue
 					}

--- a/entity/validate_test.go
+++ b/entity/validate_test.go
@@ -29,6 +29,8 @@ func TestValidateCreateEntitiesErrorsMetalabels(t *testing.T) {
 		{"a": "b", "_id": "59f10d2a5669fc79103a1111"}, // _id not allowed
 		{"a": "b", "_type": "node"},                   // _type not allowed
 		{"a": "b", "_rev": int64(0)},                  // _rev not allowed
+		{"a": "b", "_created": int64(0)},              // _created not allowed
+		{"a": "b", "_updated": int64(0)},              // _updated not allowed
 	}
 
 	for _, e := range invalid {

--- a/es/es.go
+++ b/es/es.go
@@ -453,6 +453,18 @@ func Run(ctx app.Context) {
 		return
 	}
 
+	// For the CLI, convert _created and _updated labels in place to RFC3339Nano format so they print human readable.
+	// Note that this will break entity.Created() and entity.Updated() since they expect this to be a numeric timestamp,
+	// but that's okay since the CLI just prints the entities as a map and exits.
+	for _, entity := range entities {
+		if entity["_created"] != nil {
+			entity["_created"] = entity.Created().Format(time.RFC3339Nano)
+		}
+		if entity["_updated"] != nil {
+			entity["_updated"] = entity.Updated().Format(time.RFC3339Nano)
+		}
+	}
+
 	if ctx.Options.JSON {
 		bytes, err := json.Marshal(entities)
 		if err != nil {


### PR DESCRIPTION
The code change itself is relatively small and straightforward:
* Add the new metalable in etre.go
* Add the validations in validate.go
* Maintain the label in store.go
* Update the CLI to pretty-print in a human readable form (instead of the raw Unix nano time)

The test changes were more involved, particularly because the timestamps are not deterministic. Most of the tests that validate actual data now follow a pattern where they put the actual values into the expected entity for the assert.Equal(t, expected, actual), and then do a separate check that the actual time is a realistic value (in the last few seconds).

Also fixed a bug with Entity.Rev(). It expected an int type, but json.Unmarshal sets it to a float64 which caused a panic. Now that is fixed to allow the various int flavors _and_ float.