### PR TITLE
Fix intermittent test failure

### DIFF
--- a/api/bulk_write_test.go
+++ b/api/bulk_write_test.go
@@ -78,6 +78,7 @@ func TestPostEntitiesOK(t *testing.T) {
 		{Method: "Inc", Metric: metrics.Created, IntVal: 2},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -129,6 +130,7 @@ func TestPostEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -164,6 +166,7 @@ func TestPostEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -196,6 +199,7 @@ func TestPostEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -224,6 +228,7 @@ func TestPostEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -309,6 +314,7 @@ func TestPutEntitiesOK(t *testing.T) {
 		{Method: "Inc", Metric: metrics.Updated, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -357,6 +363,7 @@ func TestPutEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -381,6 +388,7 @@ func TestPutEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -412,6 +420,7 @@ func TestPutEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, server.metricsrec.Called, expectMetrics)
 
 	// ----------------------------------------------------------------------
@@ -442,6 +451,7 @@ func TestPutEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -471,6 +481,7 @@ func TestPutEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -548,6 +559,7 @@ func TestDeleteEntitiesOK(t *testing.T) {
 		{Method: "Inc", Metric: metrics.Deleted, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -596,6 +608,7 @@ func TestDeleteEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -620,6 +633,7 @@ func TestDeleteEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, server.metricsrec.Called, expectMetrics)
 
 	// ----------------------------------------------------------------------
@@ -651,5 +665,6 @@ func TestDeleteEntitiesErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }

--- a/api/bulk_write_test.go
+++ b/api/bulk_write_test.go
@@ -421,7 +421,7 @@ func TestPutEntitiesErrors(t *testing.T) {
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
 	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
-	assert.Equal(t, server.metricsrec.Called, expectMetrics)
+	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
 	// No patch (empty payload)

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -384,9 +384,10 @@ func TestResponseCompression(t *testing.T) {
 	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
 }
 
-// fixLatencyMetric is a helper function that fixes the latency metric in the actual metrics. Since latency is non-deterministic, it can cause
-// tests to fail. This function replaces the latency metric in the actual metrics with the expected value, so that the test can pass.
-// It also asserts that the actual latency is less than the max value, to ensure that the latency is within acceptable limits.
+// fixLatencyMetric is a helper function that fixes the non-deterministic latency to ensure actual==expected for assertions.
+// Since latency is non-deterministic, it can cause tests to fail intermittently. This function replaces the latency metric
+// in the "expect" metrics with the "actual" value, so that the test can pass.
+// It also asserts that the actual latency is between 0 and the provided max value, to ensure that the latency is within acceptable limits.
 func fixLatencyMetric(t *testing.T, max int, expect, actual []mock.MetricMethodArgs) {
 	t.Helper()
 	if len(actual) != len(expect) {
@@ -395,7 +396,6 @@ func fixLatencyMetric(t *testing.T, max int, expect, actual []mock.MetricMethodA
 	}
 	for i, _ := range actual {
 		if actual[i].Metric == metrics.LatencyMs && expect[i].Metric == metrics.LatencyMs && actual[i].Method == expect[i].Method {
-			// Replace the latency metric with the expected value.
 			assert.True(t, actual[i].IntVal >= 0 && actual[i].IntVal <= int64(max), "Latency metric value %d must be between 0 and %d.", actual[i].IntVal, max)
 			expect[i].IntVal = actual[i].IntVal
 		}

--- a/api/query_test.go
+++ b/api/query_test.go
@@ -66,6 +66,7 @@ func TestQueryBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 3},              // len(testEntities)
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -110,6 +111,7 @@ func TestQueryBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 3},              // len(testEntities)
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -152,6 +154,7 @@ func TestQueryBasic(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 3},                // len(testEntities)
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -205,6 +208,7 @@ func TestQueryNoMatches(t *testing.T) {
 		{Method: "Val", Metric: metrics.ReadMatch, IntVal: 0}, // no matching queries
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -250,6 +254,7 @@ func TestQueryErrorsDatabaseError(t *testing.T) {
 		{Method: "Inc", Metric: metrics.DbError, IntVal: 1}, // db error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -345,6 +350,7 @@ func TestQueryErrorsTimeout(t *testing.T) {
 		{Method: "Inc", Metric: metrics.QueryTimeout, IntVal: 1}, // query timeout
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -376,4 +382,22 @@ func TestResponseCompression(t *testing.T) {
 
 	// Make sure content type is correct
 	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+}
+
+// fixLatencyMetric is a helper function that fixes the latency metric in the actual metrics. Since latency is non-deterministic, it can cause
+// tests to fail. This function replaces the latency metric in the actual metrics with the expected value, so that the test can pass.
+// It also asserts that the actual latency is less than the max value, to ensure that the latency is within acceptable limits.
+func fixLatencyMetric(t *testing.T, max int, expect, actual []mock.MetricMethodArgs) {
+	t.Helper()
+	if len(actual) != len(expect) {
+		// Something else is wrong, the test is going to fail anyway. Let it fail.
+		return
+	}
+	for i, _ := range actual {
+		if actual[i].Metric == metrics.LatencyMs && expect[i].Metric == metrics.LatencyMs && actual[i].Method == expect[i].Method {
+			// Replace the latency metric with the expected value.
+			assert.True(t, actual[i].IntVal >= 0 && actual[i].IntVal <= int64(max), "Latency metric value %d must be between 0 and %d.", actual[i].IntVal, max)
+			expect[i].IntVal = actual[i].IntVal
+		}
+	}
 }

--- a/api/single_entity_read_test.go
+++ b/api/single_entity_read_test.go
@@ -66,6 +66,7 @@ func TestGetEntityBasic(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ReadId, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -112,6 +113,7 @@ func TestGetEntityReturnLabels(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ReadId, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -152,6 +154,7 @@ func TestGetEntityNotFound(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ReadId, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -193,6 +196,7 @@ func TestGetEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -213,6 +217,7 @@ func TestGetEntityErrors(t *testing.T) {
 
 	// -- Metrics -----------------------------------------------------------
 	expectMetrics = []mock.MetricMethodArgs{}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -239,6 +244,7 @@ func TestGetEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.DbError, IntVal: 1}, // error
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -286,6 +292,7 @@ func TestGetEntityLabels(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ReadLabels, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------

--- a/api/single_entity_write_test.go
+++ b/api/single_entity_write_test.go
@@ -81,6 +81,7 @@ func TestPostEntityOK(t *testing.T) {
 		{Method: "Inc", Metric: metrics.Created, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -128,6 +129,7 @@ func TestPostEntityDuplicate(t *testing.T) {
 		{Method: "Inc", Metric: metrics.DbError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -177,6 +179,7 @@ func TestPostEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -207,6 +210,7 @@ func TestPostEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -234,6 +238,7 @@ func TestPostEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -309,6 +314,7 @@ func TestPutEntityOK(t *testing.T) {
 		{Method: "Inc", Metric: metrics.Updated, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -359,6 +365,7 @@ func TestPutEntityDuplicate(t *testing.T) {
 		{Method: "Inc", Metric: metrics.DbError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -404,6 +411,7 @@ func TestPutEntityNotFound(t *testing.T) {
 		//{Method: "Inc", Metric: metrics.Updated, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -442,6 +450,7 @@ func TestPutEntityErrors(t *testing.T) {
 
 	// -- Metrics -----------------------------------------------------------
 	expectMetrics := []mock.MetricMethodArgs{}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -470,6 +479,7 @@ func TestPutEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -503,6 +513,7 @@ func TestPutEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -535,6 +546,7 @@ func TestPutEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// ----------------------------------------------------------------------
@@ -564,6 +576,7 @@ func TestPutEntityErrors(t *testing.T) {
 		{Method: "Inc", Metric: metrics.ClientError, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 }
 
@@ -638,6 +651,7 @@ func TestDeleteEntityOK(t *testing.T) {
 		{Method: "Inc", Metric: metrics.Deleted, IntVal: 1},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------
@@ -711,6 +725,7 @@ func TestDeleteLabel(t *testing.T) {
 		{Method: "IncLabel", Metric: metrics.LabelDelete, StringVal: "foo"},
 		{Method: "Val", Metric: metrics.LatencyMs, IntVal: 0},
 	}
+	fixLatencyMetric(t, 150, expectMetrics, server.metricsrec.Called)
 	assert.Equal(t, expectMetrics, server.metricsrec.Called)
 
 	// -- Auth -----------------------------------------------------------


### PR DESCRIPTION
A number of Etre tests verify the server side metrics after performing some operation (create, update, delete, etc.). The existing assertions assume latency will be 0. Usually it is, but occasionaly on the GitHub servers running automated tests on the PR, the latency will be a few milliseconds. This causes the test to fail since the latency metric will have a value that doesn't match the 0 in the assertion.

To fix this, I've added a method "fixLatencyMetric". This method finds any latency metrics in the "expect" list and updates the value to match the corresponding metric from the "actual" list. To make sure the latency metric value is not garbage, fixLatencyMetrics also takes a max latency and asserts that the actual latency is between 0 and max. This way we still check the latency metric has some reasonable value, but we won't fail the test if the latency is a few milliseconds instead of 0.