### PR TITLE
Update Http return code for db insert/update failures

### DIFF
--- a/api/api_gomux.go
+++ b/api/api_gomux.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/swaggo/http-swagger"
+	httpSwagger "github.com/swaggo/http-swagger"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/square/etre"
@@ -1263,6 +1263,16 @@ func (api *API) WriteResult(rc *req, w http.ResponseWriter, ids interface{}, err
 				dupeErr.EntityId = v.EntityId
 				dupeErr.Message += " (db err: " + v.Err.Error() + ")"
 				wr.Error = &dupeErr
+			case "db-insert-one":
+				insertErr := ErrDBInsertFailed
+				insertErr.EntityId = v.EntityId
+				insertErr.Message += " (db err: " + v.Err.Error() + ")"
+				wr.Error = &insertErr
+			case "db-update-one":
+				updateErr := ErrDBUpdateFailed
+				updateErr.EntityId = v.EntityId
+				updateErr.Message += " (db err: " + v.Err.Error() + ")"
+				wr.Error = &updateErr
 			default:
 				wr.Error = &etre.Error{
 					Message:    v.Err.Error(),

--- a/api/api_gomux.go
+++ b/api/api_gomux.go
@@ -1263,12 +1263,12 @@ func (api *API) WriteResult(rc *req, w http.ResponseWriter, ids interface{}, err
 				dupeErr.EntityId = v.EntityId
 				dupeErr.Message += " (db err: " + v.Err.Error() + ")"
 				wr.Error = &dupeErr
-			case "db-insert-one":
+			case "db-insert":
 				insertErr := ErrDBInsertFailed
 				insertErr.EntityId = v.EntityId
 				insertErr.Message += " (db err: " + v.Err.Error() + ")"
 				wr.Error = &insertErr
-			case "db-update-one":
+			case "db-update":
 				updateErr := ErrDBUpdateFailed
 				updateErr.EntityId = v.EntityId
 				updateErr.Message += " (db err: " + v.Err.Error() + ")"

--- a/api/errors.go
+++ b/api/errors.go
@@ -18,6 +18,18 @@ var ErrDuplicateEntity = etre.Error{
 	Message:    "cannot insert or update entity because identifying labels conflict with another entity",
 }
 
+var ErrDBInsertFailed = etre.Error{
+	Type:       "db-insert-failed",
+	HTTPStatus: http.StatusBadRequest,
+	Message:    "failed to insert entity",
+}
+
+var ErrDBUpdateFailed = etre.Error{
+	Type:       "db-update-failed",
+	HTTPStatus: http.StatusBadRequest,
+	Message:    "failed to update entity",
+}
+
 var ErrNotFound = etre.Error{
 	Type:       "entity-not-found",
 	HTTPStatus: http.StatusNotFound,


### PR DESCRIPTION
### What and Why
Update return code for db insert/update errors from the current 503 to 400.   

### Testing

```
{"writes":[],"error":{"message":"failed to insert entity (db err: write exception: write errors: [Document failed validation: {\"failingDocumentId\": {\"$oid\":\"684373427262043d854bfdf4\"},\"details\": {\"operatorName\": \"$jsonSchema\",\"schemaRulesNotSatisfied\": [{\"operatorName\": \"required\",\"specifiedAs\": {\"required\": [\"app\",\"aws_arn\",\"aws_account_id\",\"aws_region\",\"cache_node_id\",\"replication_group_aws_arn\"]},\"missingProperties\": [\"aws_arn\",\"aws_account_id\",\"aws_region\",\"cache_node_id\",\"replication_group_aws_arn\"]}]}}])","type":"db-insert-failed","entityId":"","httpStatus":400}}
```